### PR TITLE
Fix model saving bug

### DIFF
--- a/unit_model/statistics/run_repeated_cv.py
+++ b/unit_model/statistics/run_repeated_cv.py
@@ -75,7 +75,7 @@ def main():
             # 검증 인덱스 JSON 저장
             val_file = os.path.join(args.val_idx_dir, f'val_idx_rep{rep}_fold{fold}.json')
             with open(val_file, 'w') as vf:
-                json.dump(val_indices, vf)
+                json.dump(val_indices.tolist(), vf)
 
             # evaluate_model.py 호출
             metrics_file = os.path.join(args.val_idx_dir, f'metrics_rep{rep}_fold{fold}.json')

--- a/unit_model/train/utils.py
+++ b/unit_model/train/utils.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import torch.nn.functional as F
 from eval import metrics as metrics
@@ -51,7 +52,9 @@ def evaluate(model, data_loader, device):
     return results
 
 def save_model(model, path):
-    """Save the model weights to the given file path."""
+    """Save the model weights to the given file path.
+    Creates directories if they do not exist."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     torch.save(model.state_dict(), path)
 
 def load_model(model, path, device):


### PR DESCRIPTION
## Summary
- ensure directories exist before saving model weights
- convert validation indices ndarray to list for JSON serialization

## Testing
- `python -m py_compile unit_model/train/utils.py`
- `python -m py_compile unit_model/statistics/run_repeated_cv.py`


------
https://chatgpt.com/codex/tasks/task_e_68480b69f09083209ae68e71d404186f