### PR TITLE
Fix evaluation script MKL conflict

### DIFF
--- a/unit_model/statistics/evaluate_model.py
+++ b/unit_model/statistics/evaluate_model.py
@@ -13,7 +13,12 @@ Usage:
     - 환경 변수 SOURCE_NAME, TARGET_NAME, MODEL_TYPE이 설정되어 있어야 함
 """
 
-import sys, os
+# Standard library imports
+import sys
+import os
+
+# Avoid Intel/GNU OpenMP conflicts when importing numpy/torch
+os.environ.setdefault("MKL_THREADING_LAYER", "GNU")
 # 상위 디렉토리에서 config, data, train 모듈을 불러오기 위한 경로 추가
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 

--- a/unit_model/statistics/run_repeated_cv.py
+++ b/unit_model/statistics/run_repeated_cv.py
@@ -75,7 +75,7 @@ def main():
             # 검증 인덱스 JSON 저장
             val_file = os.path.join(args.val_idx_dir, f'val_idx_rep{rep}_fold{fold}.json')
             with open(val_file, 'w') as vf:
-                json.dump(val_indices, vf)
+                json.dump(val_indices.tolist(), vf)
 
             # evaluate_model.py 호출
             metrics_file = os.path.join(args.val_idx_dir, f'metrics_rep{rep}_fold{fold}.json')

--- a/unit_model/train/utils.py
+++ b/unit_model/train/utils.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import torch.nn.functional as F
 from eval import metrics as metrics
@@ -51,7 +52,9 @@ def evaluate(model, data_loader, device):
     return results
 
 def save_model(model, path):
-    """Save the model weights to the given file path."""
+    """Save the model weights to the given file path.
+    Creates directories if they do not exist."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
     torch.save(model.state_dict(), path)
 
 def load_model(model, path, device):

--- a/unit_model/visual/f1/pvalue_test.py
+++ b/unit_model/visual/f1/pvalue_test.py
@@ -1,0 +1,38 @@
+import pandas as pd
+from scipy.stats import ttest_rel
+import os
+
+EXCEL_PATH = os.path.join(os.path.dirname(__file__), '..', 'performance_summary.xlsx')
+
+# Load the DataFrame from the 'p-value' sheet
+
+df = pd.read_excel(EXCEL_PATH, sheet_name='p-value')
+
+required = {'source', 'target', 'model_type', 'F1_finetune', 'F1_targetonly'}
+missing = required - set(df.columns)
+if missing:
+    raise ValueError(f"Missing columns: {missing}")
+
+results = []
+
+for (src, tgt, model), g in df.groupby(['source', 'target', 'model_type']):
+    sub = g[['F1_finetune', 'F1_targetonly']].dropna()
+    if len(sub) < 2:
+        continue
+    t_stat, p_val = ttest_rel(sub['F1_finetune'], sub['F1_targetonly'])
+    results.append({
+        'source': src,
+        'target': tgt,
+        'model_type': model,
+        'n': len(sub),
+        't_stat': t_stat,
+        'p_value': p_val
+    })
+
+out_df = pd.DataFrame(results)
+
+# Save results back into the Excel file
+with pd.ExcelWriter(EXCEL_PATH, mode='a', if_sheet_exists='replace') as writer:
+    out_df.to_excel(writer, sheet_name='p-value-results', index=False)
+
+print('✅ p-value calculation complete')


### PR DESCRIPTION
## Summary
- convert validation indices to lists for JSON output
- ensure model save directory is created automatically
- avoid MKL/OpenMP conflicts when running evaluation
- add script to compute p-values for each assay combination

## Testing
- `python -m py_compile unit_model/statistics/evaluate_model.py`
- `python -m py_compile unit_model/statistics/run_repeated_cv.py`
- `python -m py_compile unit_model/train/utils.py`
- `python -m py_compile unit_model/visual/f1/pvalue_test.py`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68480b69f09083209ae68e71d404186f